### PR TITLE
Add fix for trellis commands failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.2 (2022-08-10)
+## [Unreleased]
 ### Changes
 🛠 Add fix for trellis commands failure.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 (2022-08-10)
+### Changes
+🛠 Add fix for trellis commands failure.
+
 ## 2.2.1 (2022-04-06)
 ### Changes
 🛠 Add minor error handling to Stackpath and GoDaddy setup.

--- a/commands/clone.js
+++ b/commands/clone.js
@@ -58,6 +58,10 @@ async function cloneLisaProject() {
     }
   })
 
+  await exec(`trellis init`, {
+    cwd: trellisPath,
+  })
+
   await exec(`trellis dotenv`, {
     cwd: trellisPath,
   })


### PR DESCRIPTION
Run trellis init command before running trellis dotenv when cloning an existing project. 