### PR TITLE
fix(c/nspg1BSx): :bug: version lookup - both commands check version remotely @npmjs.com

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -15,23 +15,28 @@ export const versions = {
   wpCli: "2.4.0",
 }
 
+const getVersions = async () => {
+  let versionsOutput = await asyncExec(
+    `npm outdated @triggerfishab/lisa-cli --json --global --all || true`
+  )
+  return JSON.parse(versionsOutput.stdout.trim())
+}
+
 export async function checkLisaVersion() {
-  let localVersion = await asyncExec(
-    `npm show version@triggerfishab/lisa-cli version`
-  )
-  let npmVersion = await asyncExec(
-    `npm show version@triggerfishab/lisa-cli dist-tags.latest`
-  )
+  const parsedOutput = await getVersions()
+  if (Object.keys(parsedOutput).length === 0) {
+    return
+  }
 
-  localVersion = localVersion.stdout.trim()
-  npmVersion = npmVersion.stdout.trim()
-
-  if (semver.compare(localVersion, npmVersion) === -1) {
+  const versions = parsedOutput["@triggerfishab/lisa-cli"]
+  const currentVersion = versions?.current
+  const latestVersion = versions?.latest
+  if (semver.compare(currentVersion, latestVersion) === -1) {
     writeSuccess(
       `A new version of ${chalk.bold(
         "lisa-cli"
-      )} (${npmVersion}) is available, run ${chalk.bold(
-        "yarn global add @triggerfishab/lisa-cli@latest"
+      )} (${latestVersion}) is available, run ${chalk.bold(
+        "npm install @triggerfishab/lisa-cli --global"
       )} to install it.`
     )
 
@@ -46,7 +51,7 @@ export async function checkLisaVersion() {
 
     if (!continueProgram) {
       writeInfo("Exiting Lisa CLI, please upgrade the package and try again.")
-      writeInfo("yarn global add @triggerfishab/lisa-cli@latest")
+      writeInfo("npm install @triggerfishab/lisa-cli --global")
       process.exit()
     }
   }


### PR DESCRIPTION
* uses "npm outdated" method to check if package needs updating
* recommend global install of package using npm instead of yarn, since we use nvm

the gist `npm outdated @triggerfishab/lisa-cli --json --global --all || true`

ger tebax en json som är antingen 
* tomt objekt om det inte finns några uppdateringar eller
* ett objekt med paket som behöver/kan uppdateras.

måste lägga till `|| true` efter, för om det finns uppdateringar så kastar npm outdated exitcode 1. Och vår asyncExec metod hanterar inte det. det var simplare ifrån mitt håll att ändra till `|| true` än att börja dubbelkolla alla ställen metoden används

closes #17 

---

## PR Summary

* **New Function Addition: `getVersions`**
A new function named `getVersions` has been added. Its main purpose is to fetch the list of versions available for the software package `@triggerfishab/lisa-cli`. This ensures that our software fetches the most updated version information automatically.

* **Modification of `checkLisaVersion` Function**
The existing function `checkLisaVersion` has been modified to utilize the newly added `getVersions` function. It now compares the current version of `@triggerfishab/lisa-cli` with the latest available version. If it detects a newer version, it provides a user-friendly alert suggesting the user to update their `@triggerfishab/lisa-cli` package using a simple command (`npm install @triggerfishab/lisa-cli --global`). This allows users to keep their software up-to-date with minimal hassle.

