### PR TITLE
fix(sendgrid): :bug: fixing bug with uninitialized variable apiKey

### DIFF
--- a/tasks/services/sendgrid.js
+++ b/tasks/services/sendgrid.js
@@ -13,7 +13,7 @@ import {
 
 async function setupSendgridAccount() {
   let projectName = await getProjectName()
-  let apiKey = ''
+  let apiKey = ""
 
   writeStep("Creating Sendgrid subuser")
   try {

--- a/tasks/services/sendgrid.js
+++ b/tasks/services/sendgrid.js
@@ -13,10 +13,11 @@ import {
 
 async function setupSendgridAccount() {
   let projectName = await getProjectName()
+  let apiKey = ''
 
   writeStep("Creating Sendgrid subuser")
   try {
-    const apiKey = await exec(
+    apiKey = await exec(
       `op item get l2i57yslyjfr5jsieew4imwxgq --fields label="sendgrid.api key"`,
     ).then((res) => res.stdout.trim())
   } catch (error) {


### PR DESCRIPTION
- Initializing the `apiKey` variable before the try/catch statement so it is accessible before when trying to run `client.setApiKey(apiKey)`.