### PR TITLE
feat(wpUpdate): ✨ standardize composer.json settings - minimum-stability, prefer-stable - skip php extensions

### DIFF
--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -82,7 +82,7 @@ async function updateRequirePackages(
  * @returns {Promise<void>}
  */
 async function updateRequireDevPackages(composerJson, asyncExecOptions) {
-  for (const [requiredDevComposerPackage] of Object.entries(
+  for (const requiredDevComposerPackage of Object.keys(
     composerJson["require-dev"],
   )) {
     const requireCommand = `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`

--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -10,7 +10,116 @@ import {
   writeWarning,
 } from "../lib/write.js"
 
-export async function wpUpdate() {
+/**
+ * @param {object} composerJson
+ * @param {string} minimumStability
+ * @returns {void}
+ */
+function setMinimumStability(composerJson, minimumStability) {
+  if (composerJson["minimum-stability"] !== minimumStability) {
+    const updatedComposerJson = composerJson
+    updatedComposerJson["minimum-stability"] = minimumStability
+    fs.writeFileSync(
+      `${process.env.PWD}/composer.json`,
+      JSON.stringify(updatedComposerJson, null, 2),
+    )
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {boolean} preferStable
+ * @returns {void}
+ */
+function setPreferredStability(composerJson, preferStable) {
+  if (composerJson["prefer-stable"] !== preferStable) {
+    const updatedComposerJson = composerJson
+    updatedComposerJson["prefer-stable"] = preferStable
+    fs.writeFileSync(
+      `${process.env.PWD}/composer.json`,
+      JSON.stringify(updatedComposerJson, null, 2),
+    )
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {string} phpVersion
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @returns {Promise<void>}
+ */
+async function updateRequirePackages(
+  composerJson,
+  phpVersion,
+  asyncExecOptions,
+) {
+  for (const [requiredComposerPackage] of Object.entries(
+    composerJson.require,
+  )) {
+    let requireCommand = ""
+    if (requiredComposerPackage.startsWith("ext-")) {
+      continue
+    }
+    if (requiredComposerPackage === "php") {
+      requireCommand = `composer require "${requiredComposerPackage}:${phpVersion}" --with-all-dependencies --no-interaction  --ansi`
+    }
+    if (requiredComposerPackage !== "php") {
+      requireCommand = `composer require ${requiredComposerPackage} --with-all-dependencies --no-interaction --no-progress --ansi`
+    }
+    const requiredOutput = await asyncExec(requireCommand, asyncExecOptions)
+    writeInfo(`running: ${requireCommand}`)
+    console.log(requiredOutput.stdout || requiredOutput.stderr)
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @returns {Promise<void>}
+ */
+async function updateRequireDevPackages(composerJson, asyncExecOptions) {
+  for (const [requiredDevComposerPackage] of Object.entries(
+    composerJson["require-dev"],
+  )) {
+    const requireCommand = `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`
+    const requiredOutput = await asyncExec(
+      `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`,
+      asyncExecOptions,
+    )
+    writeInfo(`running: ${requireCommand}`)
+    console.log(requiredOutput.stdout || requiredOutput.stderr)
+  }
+}
+
+/**
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @return {Promise<void>}
+ */
+async function validateComposerFile(asyncExecOptions) {
+  const composerValidateOutput = await asyncExec(
+    "composer validate --no-check-all --strict --no-interaction --ansi",
+    asyncExecOptions,
+  )
+  console.log(composerValidateOutput.stdout)
+}
+
+/**
+ * @returns {object}
+ */
+function getComposerJson() {
+  return JSON.parse(fs.readFileSync(`${process.env.PWD}/composer.json`, "utf8"))
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+export default async function wpUpdate() {
   const asyncExecOptions = {
     stdio: "inherit",
     cwd: process.env.PWD,
@@ -18,44 +127,16 @@ export async function wpUpdate() {
 
   const parsedPhpVersion = semver.parse(versions.php, {})
   const phpVersion = `>=${parsedPhpVersion.major}.${parsedPhpVersion.minor}`
+  const minimumStability = "dev"
+  const preferStable = true
 
   try {
-    const composerValidateOutput = await asyncExec(
-      "composer validate --no-check-all --strict --no-interaction --ansi",
-      asyncExecOptions,
-    )
-    console.log(composerValidateOutput.stdout)
-
-    const composerJson = JSON.parse(
-      fs.readFileSync(process.env.PWD + "/composer.json", "utf8"),
-    )
-
-    for (const [requiredComposerPackage] of Object.entries(
-      composerJson.require,
-    )) {
-      let requireCommand = ""
-      if (requiredComposerPackage === "php") {
-        requireCommand = `composer require "${requiredComposerPackage}:${phpVersion}" --with-all-dependencies --no-interaction  --ansi`
-      }
-      if (requiredComposerPackage !== "php") {
-        requireCommand = `composer require ${requiredComposerPackage} --with-all-dependencies --no-interaction --no-progress --ansi`
-      }
-      let requiredOutput = await asyncExec(requireCommand, asyncExecOptions)
-      writeInfo("running: " + requireCommand)
-      console.log(requiredOutput.stdout || requiredOutput.stderr)
-    }
-
-    for (const [requiredDevComposerPackage] of Object.entries(
-      composerJson["require-dev"],
-    )) {
-      const requireCommand = `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`
-      let requiredOutput = await asyncExec(
-        `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`,
-        asyncExecOptions,
-      )
-      writeInfo("running: " + requireCommand)
-      console.log(requiredOutput.stdout || requiredOutput.stderr)
-    }
+    await validateComposerFile(asyncExecOptions)
+    const composerJson = getComposerJson()
+    setMinimumStability(composerJson, minimumStability)
+    setPreferredStability(composerJson, preferStable)
+    await updateRequirePackages(composerJson, phpVersion, asyncExecOptions)
+    await updateRequireDevPackages(composerJson, asyncExecOptions)
 
     writeWarning("Don't forget to Check your Major Updates.")
     writeSuccess("Composer update completed")

--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -55,9 +55,7 @@ async function updateRequirePackages(
   phpVersion,
   asyncExecOptions,
 ) {
-  for (const requiredComposerPackage of Object.keys(
-    composerJson.require,
-  )) {
+  for (const requiredComposerPackage of Object.keys(composerJson.require)) {
     let requireCommand = ""
     if (requiredComposerPackage.startsWith("ext-")) {
       continue

--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -55,7 +55,7 @@ async function updateRequirePackages(
   phpVersion,
   asyncExecOptions,
 ) {
-  for (const [requiredComposerPackage] of Object.entries(
+  for (const requiredComposerPackage of Object.keys(
     composerJson.require,
   )) {
     let requireCommand = ""

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import { createPageComponent } from "./commands/pageComponent.js"
 import setupPath from "./commands/path.js"
 import { createSendGrid } from "./commands/sendgrid.js"
 import writeLisaStatusSummary from "./commands/status.js"
-import { wpUpdate } from "./commands/wordpressComposerUpdate.js"
+import wpUpdate from "./commands/wordpressComposerUpdate.js"
 import { resetConf } from "./lib/conf.js"
 import { checkDependencies, checkNodeVersion } from "./lib/dependencies.js"
 import exec from "./lib/exec.js"
@@ -31,7 +31,7 @@ export const LISA_VERSION = "2.14.2"
 resetConf()
 checkNodeVersion()
 
-let command = process.argv[2]
+const command = process.argv[2]
 
 async function initProgram() {
   await checkLisaVersion()


### PR DESCRIPTION
## PR Summary

* **Introduction of New Functions in Wordpress Composer Update Module**
A number of new functions have been added in the `wordpressComposerUpdate.js` module. These functions are intended to improve package stability configurations, update required packages, validate composer files, and obtain composer JSON data.

* **Changes to the wpUpdate Function**
The `wpUpdate` function has been upgraded to make use of the newly introduced functions. This enhanced integration aims to streamline the WordPress update process, potentially contributing to overall performance improvements.

* **Revised Import Statements in Index Module**
The import terminology in `index.js` has been restructured to reliably import `wpUpdate` from the `wordpressComposerUpdate.js` module. This ensures that all necessary functions and modules are correctly and efficiently sourced when needed.

* **Command Variable Adjustment**
The `command` variable in `index.js` has been modified into a constant. This change promotes code robustness as it would prevent unintended reassignments, improving the overall stability of the application.



## Dev's Notes
### set minimum-stability to dev

[minimum-stability](https://getcomposer.org/doc/04-schema.md#minimum-stability)
This defines the default behavior for filtering packages by stability. This defaults to stable, so if you rely on a dev package, you should specify it in your file to avoid surprises.

All versions of each package are checked for stability, and those that are less stable than the minimum-stability setting will be ignored when resolving your project dependencies. (Note that you can also specify stability requirements on a per-package basis using stability flags in the version constraints that you specify in a require block (see package links for more details).

Available options (in order of stability) are dev, alpha, beta, RC, and stable.

### set prefer-stable true

[prefer-stable](https://getcomposer.org/doc/04-schema.md#prefer-stable)
When this is enabled, Composer will prefer more stable packages over unstable ones when finding compatible stable packages is possible. If you require a dev version or only alphas are available for a package, those will still be selected granted that the minimum-stability allows for it.

Use "prefer-stable": true to enable.

### skip update on  ext-* dependencies. They are always "*". since they are not installed via composer, just needed.

require and require-dev also support references to specific PHP versions and PHP extensions your project needs to run successfully.

Example:
```json
{
    "require": {
        "php": ">=8.1",
        "ext-mbstring": "*"
    }
}
```
<p><strong>Note:</strong> It is important to list PHP extensions your project requires.
Not all PHP installations are created equal: some may miss extensions you
may consider as standard (such as <code>ext-mysqli</code> which is not installed by
default in Fedora/CentOS minimal installation systems). Failure to list
required PHP extensions may lead to a bad user experience: Composer will
install your package without any errors but it will then fail at run-time.
The <code>composer show --platform</code> command lists all PHP extensions available on
your system. You may use it to help you compile the list of extensions you
use and require. Alternatively you may use third party tools to analyze
your project for the list of extensions used.</p>
