### PR TITLE
feat(wp update): ✨ fast wp update

### DIFF
--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -10,7 +10,116 @@ import {
   writeWarning,
 } from "../lib/write.js"
 
-export async function wpUpdate() {
+/**
+ * @param {object} composerJson
+ * @param {string} minimumStability
+ * @returns {void}
+ */
+function setMinimumStability(composerJson, minimumStability) {
+  if (composerJson["minimum-stability"] !== minimumStability) {
+    const updatedComposerJson = composerJson
+    updatedComposerJson["minimum-stability"] = minimumStability
+    fs.writeFileSync(
+      `${process.env.PWD}/composer.json`,
+      JSON.stringify(updatedComposerJson, null, 2),
+    )
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {boolean} preferStable
+ * @returns {void}
+ */
+function setPreferredStability(composerJson, preferStable) {
+  if (composerJson["prefer-stable"] !== preferStable) {
+    const updatedComposerJson = composerJson
+    updatedComposerJson["prefer-stable"] = preferStable
+    fs.writeFileSync(
+      `${process.env.PWD}/composer.json`,
+      JSON.stringify(updatedComposerJson, null, 2),
+    )
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {string} phpVersion
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @returns {Promise<void>}
+ */
+async function updateRequirePackages(
+  composerJson,
+  phpVersion,
+  asyncExecOptions,
+) {
+  for (const [requiredComposerPackage] of Object.entries(
+    composerJson.require,
+  )) {
+    let requireCommand = ""
+    if (requiredComposerPackage.startsWith("ext-")) {
+      continue
+    }
+    if (requiredComposerPackage === "php") {
+      requireCommand = `composer require "${requiredComposerPackage}:${phpVersion}" --with-all-dependencies --no-interaction  --ansi`
+    }
+    if (requiredComposerPackage !== "php") {
+      requireCommand = `composer require ${requiredComposerPackage} --with-all-dependencies --no-interaction --no-progress --ansi`
+    }
+    const requiredOutput = await asyncExec(requireCommand, asyncExecOptions)
+    writeInfo(`running: ${requireCommand}`)
+    console.log(requiredOutput.stdout || requiredOutput.stderr)
+  }
+}
+
+/**
+ * @param {object} composerJson
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @returns {Promise<void>}
+ */
+async function updateRequireDevPackages(composerJson, asyncExecOptions) {
+  for (const [requiredDevComposerPackage] of Object.entries(
+    composerJson["require-dev"],
+  )) {
+    const requireCommand = `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`
+    const requiredOutput = await asyncExec(
+      `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`,
+      asyncExecOptions,
+    )
+    writeInfo(`running: ${requireCommand}`)
+    console.log(requiredOutput.stdout || requiredOutput.stderr)
+  }
+}
+
+/**
+ * @param {object} asyncExecOptions
+ * @param {string} asyncExecOptions.stdio
+ * @param {string} asyncExecOptions.cwd
+ * @return {Promise<void>}
+ */
+async function validateComposerFile(asyncExecOptions) {
+  const composerValidateOutput = await asyncExec(
+    "composer validate --no-check-all --strict --no-interaction --ansi",
+    asyncExecOptions,
+  )
+  console.log(composerValidateOutput.stdout)
+}
+
+/**
+ * @returns {object}
+ */
+function getComposerJson() {
+  return JSON.parse(fs.readFileSync(`${process.env.PWD}/composer.json`, "utf8"))
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+export default async function wpUpdate() {
   const asyncExecOptions = {
     stdio: "inherit",
     cwd: process.env.PWD,
@@ -18,44 +127,16 @@ export async function wpUpdate() {
 
   const parsedPhpVersion = semver.parse(versions.php, {})
   const phpVersion = `>=${parsedPhpVersion.major}.${parsedPhpVersion.minor}`
+  const minimumStability = "dev"
+  const preferStable = true
 
   try {
-    const composerValidateOutput = await asyncExec(
-      "composer validate --no-check-all --strict --no-interaction --ansi",
-      asyncExecOptions,
-    )
-    console.log(composerValidateOutput.stdout)
-
-    const composerJson = JSON.parse(
-      fs.readFileSync(process.env.PWD + "/composer.json", "utf8"),
-    )
-
-    for (const [requiredComposerPackage] of Object.entries(
-      composerJson.require,
-    )) {
-      let requireCommand = ""
-      if (requiredComposerPackage === "php") {
-        requireCommand = `composer require "${requiredComposerPackage}:${phpVersion}" --with-all-dependencies --no-interaction  --ansi`
-      }
-      if (requiredComposerPackage !== "php") {
-        requireCommand = `composer require ${requiredComposerPackage} --with-all-dependencies --no-interaction --no-progress --ansi`
-      }
-      let requiredOutput = await asyncExec(requireCommand, asyncExecOptions)
-      writeInfo("running: " + requireCommand)
-      console.log(requiredOutput.stdout || requiredOutput.stderr)
-    }
-
-    for (const [requiredDevComposerPackage] of Object.entries(
-      composerJson["require-dev"],
-    )) {
-      const requireCommand = `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`
-      let requiredOutput = await asyncExec(
-        `composer require ${requiredDevComposerPackage} --dev --with-all-dependencies --no-interaction --no-progress --ansi`,
-        asyncExecOptions,
-      )
-      writeInfo("running: " + requireCommand)
-      console.log(requiredOutput.stdout || requiredOutput.stderr)
-    }
+    await validateComposerFile(asyncExecOptions)
+    const composerJson = getComposerJson()
+    setMinimumStability(composerJson, minimumStability)
+    setPreferredStability(composerJson, preferStable)
+    await updateRequirePackages(composerJson, phpVersion, asyncExecOptions)
+    await updateRequireDevPackages(composerJson, asyncExecOptions)
 
     writeWarning("Don't forget to Check your Major Updates.")
     writeSuccess("Composer update completed")

--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -107,6 +107,13 @@ async function updateRequirePackages(
  * @returns {Promise<void>}
  */
 async function updateRequireDevPackages(composerJson, asyncExecOptions, fast) {
+  if (
+    !Object.prototype.hasOwnProperty.call(composerJson, "require-dev") ||
+    Object.keys(composerJson["require-dev"]).length === 0
+  ) {
+    return
+  }
+
   if (fast === true) {
     const requiredDevComposerPackages = Object.keys(
       composerJson["require-dev"],

--- a/commands/wordpressComposerUpdate.js
+++ b/commands/wordpressComposerUpdate.js
@@ -11,11 +11,12 @@ import {
 } from "../lib/write.js"
 
 /**
- * @param {object} composerJson
  * @param {string} minimumStability
  * @returns {void}
  */
-function setMinimumStability(composerJson, minimumStability) {
+function setMinimumStability(minimumStability) {
+  const composerJson = getComposerJson()
+
   if (composerJson["minimum-stability"] !== minimumStability) {
     const updatedComposerJson = composerJson
     updatedComposerJson["minimum-stability"] = minimumStability
@@ -27,11 +28,12 @@ function setMinimumStability(composerJson, minimumStability) {
 }
 
 /**
- * @param {object} composerJson
  * @param {boolean} preferStable
  * @returns {void}
  */
-function setPreferredStability(composerJson, preferStable) {
+function setPreferredStability(preferStable) {
+  const composerJson = getComposerJson()
+
   if (composerJson["prefer-stable"] !== preferStable) {
     const updatedComposerJson = composerJson
     updatedComposerJson["prefer-stable"] = preferStable
@@ -184,8 +186,8 @@ export default async function wpUpdate(args, options) {
   try {
     await validateComposerFile(asyncExecOptions)
     const composerJson = getComposerJson()
-    setMinimumStability(composerJson, minimumStability)
-    setPreferredStability(composerJson, preferStable)
+    setMinimumStability(minimumStability)
+    setPreferredStability(preferStable)
     await updateRequirePackages(
       composerJson,
       phpVersion,

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ async function initProgram() {
     .action(wpUpdate)
     .option(
       "-f, --fast",
-      "Combines all commands into one, for example: lisa wp update fast",
+      "combines required packages and required-dev packages into one command into one line",
       false,
     )
 

--- a/index.js
+++ b/index.js
@@ -122,12 +122,16 @@ async function initProgram() {
 
   program
     .command("wp update")
-    .description(
-      `Update WordPress and Composer dependencies.
-Make sure your standing in the folder where your composer.json file is located.
-    `,
+    .description("Update WordPress and Composer dependencies.")
+    .addHelpCommand(
+      "Make sure your standing in the folder where your composer.json file is located.",
     )
     .action(wpUpdate)
+    .option(
+      "-f, --fast",
+      "Combines all commands into one, for example: lisa wp update fast",
+      false,
+    )
 
   program
     .command("godaddy create")

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import { createPageComponent } from "./commands/pageComponent.js"
 import setupPath from "./commands/path.js"
 import { createSendGrid } from "./commands/sendgrid.js"
 import writeLisaStatusSummary from "./commands/status.js"
-import { wpUpdate } from "./commands/wordpressComposerUpdate.js"
+import wpUpdate from "./commands/wordpressComposerUpdate.js"
 import { resetConf } from "./lib/conf.js"
 import { checkDependencies, checkNodeVersion } from "./lib/dependencies.js"
 import exec from "./lib/exec.js"
@@ -31,7 +31,7 @@ export const LISA_VERSION = "2.14.2"
 resetConf()
 checkNodeVersion()
 
-let command = process.argv[2]
+const command = process.argv[2]
 
 async function initProgram() {
   await checkLisaVersion()


### PR DESCRIPTION
check #73 first

## Dev's Notes
Add --fast parameter to wp update command, it will chain all requires into one command.

example
**without** _--fast_
```sh
composer require composer/installers -W
composer require roots/acorn -W
composer require roots/wordpress -W
composer require rector/rector -W --dev
composer require squizlabs/php_codesniffer -W --dev
composer require johnbillion/query-monitor -W --dev
```
**with** _--fast_
```sh
composer require composer/installers roots/acorn roots/wordpress -W
composer require rector/rector squizlabs/php_codesniffer johnbillion/query-monitor -W --dev
```

### Added
- [x] Adds --fast parameter to wp update command