### PR TITLE
fix(fig-commander): Remove @fig/complete-commander dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-import { generateCompletionSpec } from "@fig/complete-commander"
 import chalk from "chalk"
 import { Command } from "commander"
-import fs from "fs"
 
 import {
   createCdnS3GoDaddy,
@@ -155,13 +153,6 @@ Make sure your standing in the folder where your composer.json file is located.
     )
     .action(generateVaultPass)
 
-  if (process.env.NODE_ENV === "development") {
-    const lisaFigSecContent = generateCompletionSpec(program)
-    const lisaFigSecPath = `${process.env.HOME}/.fig/autocomplete/lisa.ts`
-    fs.writeFileSync(lisaFigSecPath, lisaFigSecContent, { encoding: "utf8" })
-    // npx @fig/publish-spec@latest --spec-path ~/.fig/autocomplete/lisa.ts
-    // npx @fig/publish-spec@latest --spec-path ~/.fig/autocomplete/lisa.ts --team triggerfish
-  }
   program.parse()
 }
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ import { checkLisaVersion } from "./lib/versions.js"
 import { generateVaultPass } from "./tasks/trellis.js"
 
 export const program = new Command()
-export const LISA_VERSION = "2.16.0"
+export const LISA_VERSION = "2.16.1"
 
 resetConf()
 checkNodeVersion()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triggerfishab/lisa-cli",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "CLI commands to generate a new project based on Lisa",
   "main": "./index.js",
   "bin": {
@@ -32,7 +32,6 @@
     "semver": "^7.3.8"
   },
   "devDependencies": {
-    "@fig/complete-commander": "^2.0.1",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "@types/node": "^20.8.6",
     "eslint": "^8.51.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,13 +837,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.51.0.tgz#6d419c240cfb2b66da37df230f7e7eef801c32fa"
   integrity sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==
 
-"@fig/complete-commander@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@fig/complete-commander/-/complete-commander-2.0.1.tgz#6dd84f8812389107529aaedebd1bb67ac8bc16c6"
-  integrity sha512-AbGETely7iwD4F7XHe4g7pW6icWYYqJMdQog8CdEi9syU/av5L0O24BvCfgEeGO6TRPMpC+rFL7ZDJsqRtckOA==
-  dependencies:
-    prettier "^2.3.2"
-
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"
@@ -2962,11 +2955,6 @@ prettier-linter-helpers@^1.0.0:
   integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
   dependencies:
     fast-diff "^1.1.2"
-
-prettier@^2.3.2:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 prettier@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
## PR Summary
wtd:summary

## Dev's Notes
This commit removes the "@fig/complete-commander" package from devDependencies in package.json. It also eliminates corresponding lockfile entries in yarn.lock as well as related import and usage lines in index.js.